### PR TITLE
Examples added and README updated

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ beards
 ```
 
 In this example the `myBeard` folder containts a `requirements.txt` for any additonal dependencies so they can be pipped, a `config.py` file for configuration of the beard and settings and the `__init__.py` which contains the class that that is the interface between the plug-in and skybeard. 
-This interface class uses the mixin `skybeard.beards.BeardAsyncChatHandlerMixin` which handles the mounting of the plug-in, registering of commands etc, and also the `telepot.aio.helper.ChatHandler`. 
+This interface class inherits from skybeard.beards.BeardChatHandler` which handles the mounting of the plug-in, registering of commands etc, and also the `telepot.aio.helper.ChatHandler`. 
 
 The folder can also contain any other python modules and files that are needed for the plugin.
 
@@ -50,10 +50,10 @@ An example async plug-in that would echo the user's message would look like this
 ```
 import telepot
 import telepot.aio
-from skybeard.beards import BeardAsyncChatHandlerMixin
+from skybeard.beards import BeardChatHandler
 
 
-class EchoPlugin(telepot.aio.helper.ChatHandler, BeardAsyncChatHandlerMixin):
+class EchoPlugin(telepot.aio.helper.ChatHandler, BeardChatHandler):
     
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
@@ -72,7 +72,7 @@ class EchoPlugin(telepot.aio.helper.ChatHandler, BeardAsyncChatHandlerMixin):
         await super().on_chat_message(msg)
 ```
 
-This plug-in will greet the user when they send "/hello" to Skybeard by using the `register_command()` method of the `BeardAsyncChatHandlerMixin` and will also echo back any text the user sends by overwriting the `on_chat_message()` method (and calling the base method with `super()` afterwards).
+This plug-in will greet the user when they send "/hello" to Skybeard by using the `register_command()` method of the `BeardChatHandler` and will also echo back any text the user sends by overwriting the `on_chat_message()` method (and calling the base method with `super()` afterwards).
 
 See the examples folder for examples of callback functionality, timers, and regex predication. 
 

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -1,0 +1,4 @@
+To use these examples just add the 'examples/' path to the
+main config.py and the names of the folders ofany you wish
+to add (if set to 'all', they will all be loaded 
+automatically.

--- a/examples/callback/__init__.py
+++ b/examples/callback/__init__.py
@@ -1,0 +1,39 @@
+import logging
+import telepot
+import telepot.aio
+from telepot import glance
+from telepot.namedtuple import InlineKeyboardMarkup, InlineKeyboardButton
+from skybeard.beards import BeardChatHandler
+
+logger = logging.getLogger(__name__)
+
+class CallbackTestBeard(BeardChatHandler):
+    '''Simple callback button example for skybeard-2
+    Type /callbackstart to begin.
+    '''
+    _timeout = 10
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.register_command('callbackstart', self.start)
+
+        self.keyboard = InlineKeyboardMarkup(
+            inline_keyboard=[
+                [InlineKeyboardButton(text='Option 1', callback_data='1'),
+                 InlineKeyboardButton(text='Option 2', callback_data='2')],
+                [InlineKeyboardButton(text='Option 3', callback_data='3')],
+            ])
+
+    __userhelp__ = '''/callbackstart to test callbacks.'''
+
+    async def start(self, msg):
+        await self.sender.sendMessage('Please choose:',
+                                      reply_markup=self.keyboard)
+
+    async def on_callback_query(self, msg):
+        query_id, from_id, query_data = glance(msg, flavor='callback_query')
+
+        await self.bot.editMessageText(
+            telepot.origin_identifier(msg),
+            text="Selected option: {}".format(query_data),
+            reply_markup=self.keyboard)

--- a/examples/dice/__init__.py
+++ b/examples/dice/__init__.py
@@ -1,0 +1,45 @@
+import logging
+import dice
+import re
+
+import telepot
+import telepot.aio
+from skybeard.beards import BeardChatHandler
+
+logger = logging.getLogger(__name__)
+
+def get_args(msg_text):
+    return msg_text.split(" ")[1:]
+
+#user unicode characters of dice faces
+dice_faces = {
+    1: "\u2680",
+    2: "\u2681",
+    3: "\u2682",
+    4: "\u2683",
+    5: "\u2684",
+    6: "\u2685",
+}
+
+class DiceBeard(BeardChatHandler):
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        #register command which calls self.roll function
+        self.register_command("roll", self.roll)
+
+    async def roll(self, msg):
+        roll_text = " ".join(get_args(msg['text'])) or "3d6"
+        roll = dice.roll(roll_text)
+        if re.match(r"^[0-9]d6$", roll_text):
+            text = "{} = {}".format(sum(roll),
+                                    "".join(dice_faces[x] for x in roll))
+        else:
+            try:
+                text = "{} = {}".format(sum(roll), roll)
+            except TypeError:
+                text = "{}".format(roll)
+
+        await self.sender.sendMessage("{}".format(text))
+
+__userhelp__ = """Rolls dice."""

--- a/examples/echo/__init__.py
+++ b/examples/echo/__init__.py
@@ -1,0 +1,21 @@
+import telepot
+import telepot.aio
+from skybeard.beards import BeardAsyncChatHandlerMixin
+
+class Echo(BeardChatHandler):
+    
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        #register command "/hello" to dispatch to self.say_hello()
+        self.register_command("hello", self.say_hello)
+    
+    #is called when "/hello" is sent
+    async def say_hello(self, msg):
+        name = msg['from']['first_name']
+        await self.sender.sendMessage('Hello {}!'.format(name))
+    
+    #is called every time a message is sent
+    async def on_chat_message(self, msg):
+        text = msg['text']
+        await self.sender.sendMessage(text)
+        await super().on_chat_message(msg)


### PR DESCRIPTION
Added examples for echo, callback buttons and dice roll. Example echo beard in README now uses `BeardChatHandler` instead of the old `BeardAsyncChatHandlerMixin`.