### PR TITLE
[WIP]Added dry run option for skybeard.

### DIFF
--- a/main.py
+++ b/main.py
@@ -171,6 +171,16 @@ def main():
         list(delegator_beard_gen(Beard.beards))
     )
 
+    if pyconfig.get('dry_run'):
+        logger.info(
+            "Dry run successful! Exciting normally before getting the loop...")
+
+        # This needs to be done manually as telepot expects you to run the bot
+        telepot.aio.api._pools['default'].close()
+
+        logger.info("So long, and thanks for all the fish!")
+        return
+
     loop = asyncio.get_event_loop()
 
     async def bot_message_loop_and_aiothttp_session():
@@ -241,6 +251,8 @@ if __name__ == '__main__':
                         default=False)
     parser.add_argument('--auto-pip-upgrade', action='store_const', const=True,
                         default=False)
+    parser.add_argument('--dry-run', action='store_const', const=True,
+                        default=False)
 
     parsed = parser.parse_args()
 
@@ -263,6 +275,7 @@ if __name__ == '__main__':
     pyconfig.set('auto_pip_upgrade', parsed.auto_pip_upgrade)
     pyconfig.set('admins', [a[1] for a in pyconfig.get('admins')])
     print(pyconfig.get('admins'))
+    pyconfig.set('dry_run', parsed.dry_run)
 
     logging.basicConfig(
         format='%(asctime)s - %(name)s - %(levelname)s - %(message)s',


### PR DESCRIPTION
Skybeard now has a `--dry-run` option which imports all beards and does everything except start the server and start the bot.

```
$ ./main.py -k FAKEKEY --dry-run
[89593615]
2017-06-22 11:31:19,659 - pyconfig - INFO -     key = 'FAKEKEY'
2017-06-22 11:31:19,660 - pyconfig - INFO -     db_url = 'sqlite:///../db/skybeard-2.db'
Collecting git+git://github.com/nasfarley88/pydice.git (from -r /home/nasfarley88/git/dicebeard/requirements.txt (line 3))
  Cloning git://github.com/nasfarley88/pydice.git to /tmp/pip-059kmivr-build
  Requirement already satisfied (use --upgrade to upgrade): pydice==1.0.1b5 from git+git://github.com/nasfarley88/pydice.git in /home/nasfarley88/.pyenv/versions/3.5.1/envs/turbo-goggles/lib/python3.5/site-packages (from -r /home/nasfarley88/git/dicebeard/requirements.txt (line 3))
Requirement already satisfied: dice<=1.1.0 in /home/nasfarley88/.pyenv/versions/3.5.1/envs/turbo-goggles/lib/python3.5/site-packages (from -r /home/nasfarley88/git/dicebeard/requirements.txt (line 1))
Requirement already satisfied: pillow>=4.0.0 in /home/nasfarley88/.pyenv/versions/3.5.1/envs/turbo-goggles/lib/python3.5/site-packages (from -r /home/nasfarley88/git/dicebeard/requirements.txt (line 2))
Requirement already satisfied: numpy in /home/nasfarley88/.pyenv/versions/3.5.1/envs/turbo-goggles/lib/python3.5/site-packages (from -r /home/nasfarley88/git/dicebeard/requirements.txt (line 4))
Requirement already satisfied: six in /home/nasfarley88/.pyenv/versions/3.5.1/envs/turbo-goggles/lib/python3.5/site-packages (from pydice==1.0.1b5->-r /home/nasfarley88/git/dicebeard/requirements.txt (line 3))
Requirement already satisfied: docopt>=0.6.1 in /home/nasfarley88/.pyenv/versions/3.5.1/envs/turbo-goggles/lib/python3.5/site-packages (from dice<=1.1.0->-r /home/nasfarley88/git/dicebeard/requirements.txt (line 1))
Requirement already satisfied: pyparsing>=2.0.1 in /home/nasfarley88/.pyenv/versions/3.5.1/envs/turbo-goggles/lib/python3.5/site-packages (from dice<=1.1.0->-r /home/nasfarley88/git/dicebeard/requirements.txt (line 1))
Requirement already satisfied: olefile in /home/nasfarley88/.pyenv/versions/3.5.1/envs/turbo-goggles/lib/python3.5/site-packages (from pillow>=4.0.0->-r /home/nasfarley88/git/dicebeard/requirements.txt (line 2))
2017-06-22 11:31:21,344 - __main__ - WARNING - Attempting to import oldstyle_beard as an old style beard. Old beards will eventually be deprecated.
2017-06-22 11:31:21,345 - __main__ - INFO - Dry run successful! Exciting normally before getting the loop...
2017-06-22 11:31:21,345 - __main__ - INFO - So long, and thanks for all the fish!
```

This is so that we can have a real test to see if our integration tests will actually import (and whether they can exist without keys. In the future, this will mean we can test whether beards will work 'out of the box' automatically by adding the beards to the config and running with `--dry-run`.

@artemis-beta Would you be interested in creating the test for the default config?